### PR TITLE
removing CheckScriptUpdate() from most child scripts

### DIFF
--- a/BPTV-CHEAT-SHEETS.ahk
+++ b/BPTV-CHEAT-SHEETS.ahk
@@ -13,11 +13,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #HotkeyModifierTimeout 0 ;It's not clear if this completely fixes it.
 SetTitleMatchMode, 2 ; sets title matching to search for "containing" instead of "exact"
 
-; The 2 lines below pertain to the 'reload on save' function below (CheckScriptUpdate).
-; They are required for it to work.
-FileGetTime ScriptStartModTime, %A_ScriptFullPath%
-SetTimer CheckScriptUpdate, 100, 0x7FFFFFFF ; 100 ms, highest priority
-
 Menu, Tray, Icon, shell32.dll, 214 ;tray icon is now a little keyboard, or piece of paper or something
 
 ;===== INITIALIZATION - VARIABLES ==============================================================
@@ -46,6 +41,7 @@ SetTimer, RemoveSplashScreen, %splashScreenTimeout%
 Sleep, sleepDeep
 SplashTextOff
 
+
 ;===== END OF AUTO-EXECUTE =====================================================================
 ;===== MODIFIER MEMORY HELPER ==================================================================
 ; combine below with key and '::' to define hotkey
@@ -53,7 +49,7 @@ SplashTextOff
 ; #=Win | !=Alt | ^=Ctrl | +=Shift | &=combine keys | *=ignore other mods
 ; <=use left mod key| >=use right mod key  | UP=fires on release
 
-;===== MAIN HOTKEY DEFINITIONS HERE ============================================================
+;===== MAIN HOTKEY DEFINITIONS HERE ============================================================ 
 CapsLock & F1:: ; <--Display a Text File CheatSheet of MASTER-SCRIPT AutoHotKeys based on Location setting.
     WinGetActiveTitle, activeWin ; We need to capture whatever was the Window that had focus when this was launched, otherwise it will give focus to whichever Window had focus before that (or some random Window).
     txt2show := "SUPPORTING-FILES\KBF1-LOC" . Location_currentSystemLocation . ".txt"
@@ -228,24 +224,4 @@ showImageTabs(picToshow, PictureWidth, numPages){
     Gui, Picture:Tab
     Gui, Picture:Show
     return
-}
-
-
-; This function will auto-reload the script on save.
-CheckScriptUpdate() {
-    global ScriptStartModTime
-    FileGetTime curModTime, %A_ScriptFullPath%
-    If (curModTime <> ScriptStartModTime) {
-        Loop
-        {
-            Run, "MASTER-SCRIPT.ahk" ; When run as part of the full BPTV-KB Suite, this script needs to be reloaded from MASTER-SCRIPT.ahk. It pulls location & other info from what that script reads from 'settings.ini' so this command will cause the whole suite to reload on save of changes to this file.
-            ;reload ; If you are running just this script by itself, you can comment the line above out & uncomment this line, so that it will just reload itself after you save it.
-            Sleep 3000 ; ms
-            MsgBox 0x2, %A_ScriptName%, Reload failed. ; 0x2 = Abort/Retry/Ignore
-            IfMsgBox Abort
-                ExitApp
-            IfMsgBox Ignore
-                break
-        } ; loops reload on "Retry"
-    }
 }

--- a/SCRIPTS-PPRO/PREMIERE-PRO-HOTKEYS.ahk
+++ b/SCRIPTS-PPRO/PREMIERE-PRO-HOTKEYS.ahk
@@ -12,11 +12,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #MaxHotkeysPerInterval 2000
 #WinActivateForce ;https://autohotkey.com/docs/commands/_WinActivateForce.htm
 
-; The 2 lines below pertain to the 'reload on save' function below (CheckScriptUpdate).
-; They are required for it to work.
-FileGetTime ScriptStartModTime, %A_ScriptFullPath%
-SetTimer CheckScriptUpdate, 100, 0x7FFFFFFF ; 100 ms, highest priority
-
 Menu, Tray, Icon, shell32.dll, 116 ; this changes the tray icon to a filmstrip!
 ;===== INITIALIZATION - VARIABLES ==============================================================
 ; Sleep shortcuts - use these to standardize sleep times. Change here to change everywhere.
@@ -253,21 +248,3 @@ RemoveSplashScreen:
     SplashTextOff
     SetTimer RemoveSplashScreen, Off
     return
-
-; This function will auto-reload the script on save.
-CheckScriptUpdate() {
-    global ScriptStartModTime
-    FileGetTime curModTime, %A_ScriptFullPath%
-    If (curModTime <> ScriptStartModTime) {
-        Loop
-        {
-            reload
-            Sleep 300 ; ms
-            MsgBox 0x2, %A_ScriptName%, Reload failed. ; 0x2 = Abort/Retry/Ignore
-            IfMsgBox Abort
-                ExitApp
-            IfMsgBox Ignore
-                break
-        } ; loops reload on "Retry"
-    }
-}

--- a/SCRIPTS-PSHOP/PHOTOSHOP-HOTKEYS.ahk
+++ b/SCRIPTS-PSHOP/PHOTOSHOP-HOTKEYS.ahk
@@ -12,10 +12,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #MaxHotkeysPerInterval 2000
 #WinActivateForce ;https://autohotkey.com/docs/commands/_WinActivateForce.htm
 
-; The 2 lines below pertain to the 'reload on save' function below (CheckScriptUpdate).
-; They are required for it to work.
-FileGetTime ScriptStartModTime, %A_ScriptFullPath%
-SetTimer CheckScriptUpdate, 100, 0x7FFFFFFF ; 100 ms, highest priority
 
 Menu, Tray, Icon, shell32.dll, 110 ; this changes the tray icon to a filmstrip!
 ;===== INITIALIZATION - VARIABLES ==============================================================
@@ -74,7 +70,7 @@ Send, {CTRL Down}
 Sleep, sleepShort
 Send, V
 Sleep, sleepShort
-Send, {CTRL Up}   
+Send, {CTRL Up}
 Sleep, sleepShort
 WinActivate, ahk_exe Photoshop.exe
 return
@@ -101,12 +97,12 @@ Sleep, sleepShort
 MouseMove, %posX%, %posY%
 return
 
-;+^!f3:: 
-;+^!f4:: 
+;+^!f3::
+;+^!f4::
 ;+^!f5::
 ;+^!f6::
-;+^!f7:: 
-;+^!f8:: 
+;+^!f7::
+;+^!f8::
 ;+^!f9::
 ;+^!f10::
 ;+^!f11::
@@ -126,21 +122,3 @@ RemoveSplashScreen:
     SplashTextOff
     SetTimer RemoveSplashScreen, Off
     return
-
-; This function will auto-reload the script on save.
-CheckScriptUpdate() {
-    global ScriptStartModTime
-    FileGetTime curModTime, %A_ScriptFullPath%
-    If (curModTime <> ScriptStartModTime) {
-        Loop
-        {
-            reload
-            Sleep 300 ; ms
-            MsgBox 0x2, %A_ScriptName%, Reload failed. ; 0x2 = Abort/Retry/Ignore
-            IfMsgBox Abort
-                ExitApp
-            IfMsgBox Ignore
-                break
-        } ; loops reload on "Retry"
-    }
-}

--- a/SCRIPTS-UTIL/ATOM-AHK.ahk
+++ b/SCRIPTS-UTIL/ATOM-AHK.ahk
@@ -11,10 +11,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #SingleInstance force ; Ensures that there is only a single instance of this script running.
 ; SetTitleMatchMode, 2 ; sets title matching to search for "containing" instead of "exact"
 
-; The 2 lines below pertain to the 'reload on save' function below (CheckScriptUpdate).
-; They are required for it to work.
-FileGetTime ScriptStartModTime, %A_ScriptFullPath%
-SetTimer CheckScriptUpdate, 100, 0x7FFFFFFF ; 100 ms, highest priority
 
 ;===== INITIALIZATION - VARIABLES ==============================================================
 ; Sleep shortcuts - use these to standardize sleep times. Change here to change everywhere.
@@ -152,21 +148,3 @@ RemoveSplashScreen:
     SplashTextOff
     SetTimer RemoveSplashScreen, Off
     return
-
-; This function will auto-reload the script on save.
-CheckScriptUpdate() {
-    global ScriptStartModTime
-    FileGetTime curModTime, %A_ScriptFullPath%
-    If (curModTime <> ScriptStartModTime) {
-        Loop
-        {
-            reload
-            Sleep 300 ; ms
-            MsgBox 0x2, %A_ScriptName%, Reload failed. ; 0x2 = Abort/Retry/Ignore
-            IfMsgBox Abort
-                ExitApp
-            IfMsgBox Ignore
-                break
-        } ; loops reload on "Retry"
-    }
-}

--- a/SCRIPTS-UTIL/FavoritesMenu.ahk
+++ b/SCRIPTS-UTIL/FavoritesMenu.ahk
@@ -15,12 +15,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 ;#WinActivateForce ;https://autohotkey.com/docs/commands/_WinActivateForce.htm
 
 
-
-; The 2 lines below pertain to the 'reload on save' function below (CheckScriptUpdate).
-; They are required for it to work.
-FileGetTime ScriptStartModTime, %A_ScriptFullPath%
-SetTimer CheckScriptUpdate, 100, 0x7FFFFFFF ; 100 ms, highest priority
-
 Menu, Tray, Icon, shell32.dll, 111 ; this changes the tray icon to a folder with a menu
 ;===== INITIALIZATION - VARIABLES ==============================================================
 ; Sleep shortcuts - use these to standardize sleep times. Change here to change everywhere.
@@ -259,21 +253,3 @@ RemoveSplashScreen:
     SplashTextOff
     SetTimer RemoveSplashScreen, Off
     return
-
-; This function will auto-reload the script on save.
-CheckScriptUpdate() {
-    global ScriptStartModTime
-    FileGetTime curModTime, %A_ScriptFullPath%
-    If (curModTime <> ScriptStartModTime) {
-        Loop
-        {
-            reload
-            Sleep 300 ; ms
-            MsgBox 0x2, %A_ScriptName%, Reload failed. ; 0x2 = Abort/Retry/Ignore
-            IfMsgBox Abort
-                ExitApp
-            IfMsgBox Ignore
-                break
-        } ; loops reload on "Retry"
-    }
-}

--- a/version.ini
+++ b/version.ini
@@ -1,1 +1,1 @@
-v0.3.0 - SeaBeams
+v0.3.1 - SeaBeams


### PR DESCRIPTION
In an effort to cut down on overhead, I've removed the CheckScriptUpdate() from most child scripts. In order to get any updated child script to reload, you will now need to reload MASTER-SCRIPT.ahk